### PR TITLE
Protocol support

### DIFF
--- a/src/spy/alpha.clj
+++ b/src/spy/alpha.clj
@@ -11,5 +11,7 @@
 (defmacro protocol-spy [protocol spies]
   (let [signatures (:sigs @(resolve protocol))
         methods (protocol-methods signatures spies)]
-    `(reify ~protocol
-       ~@methods)))
+    (with-meta
+      `(reify ~protocol
+         ~@methods)
+      spies)))

--- a/src/spy/alpha.clj
+++ b/src/spy/alpha.clj
@@ -1,0 +1,15 @@
+(ns spy.alpha)
+
+(defn signature->method [spies [k {:keys [arglists name]}]]
+  (for [args arglists]
+    `(~name ~args
+      (apply (get ~spies ~k) ~args))))
+
+(defn protocol-methods [signatures spies]
+  (mapcat (partial signature->method spies) signatures))
+
+(defmacro protocol-spy [protocol spies]
+  (let [signatures (:sigs @(resolve protocol))
+        methods (protocol-methods signatures spies)]
+    `(reify ~protocol
+       ~@methods)))

--- a/src/spy/alpha.clj
+++ b/src/spy/alpha.clj
@@ -1,19 +1,65 @@
-(ns spy.alpha)
+(ns spy.alpha
+  (:require [spy.core :as spy]))
 
-(defn signature->method [spies [k v]]
+#_(defn signature->method [spies [k v]]
   (for [args (:arglists v)]
     `(~(:name v) ~args
       (apply (get ~spies ~k) ~args))))
 
-(defn protocol-methods [signatures spies]
+#_(defn protocol-methods [signatures spies]
   (mapcat (partial signature->method spies) signatures))
+
+#_(defn method-spies [signatures]
+  (reduce (fn [m [k v]]
+            (assoc m k `(spy/spy)))
+          {}
+          signatures))
+
+(defn pmethods [signatures]
+  (loop [signatures signatures
+         processing nil
+         mthds []]
+    (if processing
+      (if (empty? (:arglists processing))
+        (recur signatures nil mthds)
+        (recur signatures
+               (update processing :arglists rest)
+               (conj mthds {:name (:name processing)
+                            :args (-> processing :arglists first)})))
+      (if (empty? signatures)
+        mthds
+        (let [[_ to-process] (first signatures)]
+          (recur (rest signatures) to-process mthds))))))
+
 
 ;; TODO - generate default empty spies if no spy passed in
 ;; TODO - sugar to generate stubs/spies?
-(defmacro protocol-spy [protocol spies]
+#_(defmacro protocol-spy [protocol & spies]
   (let [signatures (:sigs @(resolve protocol))
+        spies (merge (method-spies signatures) (first spies))
         methods (protocol-methods signatures spies)]
-    (with-meta
-      `(reify ~protocol
-         ~@methods)
-      spies)))
+    `(let [spies# ~spies]
+       (with-meta
+         (reify ~protocol
+           ~@(mapcat (fn [[k v]]
+                       (for [args (:arglists v)]
+                         `(~(:name v) ~args
+                           (apply (get ~spies ~k) ~args)))) signatures))
+         'spies#))))
+
+(defmacro defspy [record-name protocol]
+  (let [protocol-sigs (:sigs @(resolve protocol))
+        signatures (pmethods protocol-sigs)
+        fields (->> protocol-sigs keys (map (comp symbol name)))]
+    `(defrecord ~record-name [~@fields]
+       ~protocol
+       ~@(map (fn [{:keys [name args]}]
+                `(~name ~args
+                  ((~(keyword name) ~(first args)) ~@args))) signatures))))
+
+#_(defn createspy [protocol record-name & [spies]]
+  (let [protocol-sigs (:sigs protocol)
+        spy-fns (into {} (map (fn [[k v]]
+                                {k (get spies k (spy/spy))}) protocol-sigs))
+        fields (->> protocol-sigs keys (map (comp symbol name)))]
+    ((symbol (str "map->" (name record-name))) spy-fns)))

--- a/src/spy/alpha.clj
+++ b/src/spy/alpha.clj
@@ -8,6 +8,8 @@
 (defn protocol-methods [signatures spies]
   (mapcat (partial signature->method spies) signatures))
 
+;; TODO - generate default empty spies if no spy passed in
+;; TODO - sugar to generate stubs/spies?
 (defmacro protocol-spy [protocol spies]
   (let [signatures (:sigs @(resolve protocol))
         methods (protocol-methods signatures spies)]

--- a/src/spy/alpha.clj
+++ b/src/spy/alpha.clj
@@ -1,21 +1,10 @@
 (ns spy.alpha
   (:require [spy.core :as spy]))
 
-#_(defn signature->method [spies [k v]]
-  (for [args (:arglists v)]
-    `(~(:name v) ~args
-      (apply (get ~spies ~k) ~args))))
-
-#_(defn protocol-methods [signatures spies]
-  (mapcat (partial signature->method spies) signatures))
-
-#_(defn method-spies [signatures]
-  (reduce (fn [m [k v]]
-            (assoc m k `(spy/spy)))
-          {}
-          signatures))
-
-(defn pmethods [signatures]
+(defn pmethods
+  "Generate a list of method that need to be implemented for
+  the protocol signatures"
+  [signatures]
   (loop [signatures signatures
          processing nil
          mthds []]
@@ -31,23 +20,9 @@
         (let [[_ to-process] (first signatures)]
           (recur (rest signatures) to-process mthds))))))
 
-
-;; TODO - generate default empty spies if no spy passed in
-;; TODO - sugar to generate stubs/spies?
-#_(defmacro protocol-spy [protocol & spies]
-  (let [signatures (:sigs @(resolve protocol))
-        spies (merge (method-spies signatures) (first spies))
-        methods (protocol-methods signatures spies)]
-    `(let [spies# ~spies]
-       (with-meta
-         (reify ~protocol
-           ~@(mapcat (fn [[k v]]
-                       (for [args (:arglists v)]
-                         `(~(:name v) ~args
-                           (apply (get ~spies ~k) ~args)))) signatures))
-         'spies#))))
-
-(defmacro defspy [record-name protocol]
+(defmacro defspy
+  "Generates a record that implements the protocol"
+  [record-name protocol]
   (let [protocol-sigs (:sigs @(resolve protocol))
         signatures (pmethods protocol-sigs)
         fields (->> protocol-sigs keys (map (comp symbol name)))]
@@ -55,11 +30,18 @@
        ~protocol
        ~@(map (fn [{:keys [name args]}]
                 `(~name ~args
-                  ((~(keyword name) ~(first args)) ~@args))) signatures))))
+                  ((~(keyword name) ~(first args)) ~@args)))
+              signatures))))
 
-#_(defn createspy [protocol record-name & [spies]]
-  (let [protocol-sigs (:sigs protocol)
-        spy-fns (into {} (map (fn [[k v]]
-                                {k (get spies k (spy/spy))}) protocol-sigs))
-        fields (->> protocol-sigs keys (map (comp symbol name)))]
-    ((symbol (str "map->" (name record-name))) spy-fns)))
+(defmacro protocol-spy
+  "Generates a record implementing the protocol and creates a new instance
+  of the record with the spies provided."
+  [protocol & [spies]]
+  (let [signatures (:sigs @(resolve protocol))
+        rname (gensym protocol)]
+    `(do
+       (defspy ~rname ~protocol)
+       (~(symbol (str 'map-> rname))
+        ~(into {} (map (fn [[k v]]
+                         {k (get spies k '(spy/spy))})
+                       signatures))))))

--- a/src/spy/alpha.clj
+++ b/src/spy/alpha.clj
@@ -1,8 +1,8 @@
 (ns spy.alpha)
 
-(defn signature->method [spies [k {:keys [arglists name]}]]
-  (for [args arglists]
-    `(~name ~args
+(defn signature->method [spies [k v]]
+  (for [args (:arglists v)]
+    `(~(:name v) ~args
       (apply (get ~spies ~k) ~args))))
 
 (defn protocol-methods [signatures spies]

--- a/src/spy/protocol.clj
+++ b/src/spy/protocol.clj
@@ -1,7 +1,6 @@
-(ns spy.alpha
-  (:require [spy.core :as spy]))
+(ns spy.protocol)
 
-(defn pmethods
+(defn protocol-methods
   "Generate a list of method that need to be implemented for
   the protocol signatures"
   [signatures]
@@ -24,7 +23,7 @@
   "Generates a record that implements the protocol"
   [record-name protocol]
   (let [protocol-sigs (:sigs @(resolve protocol))
-        signatures (pmethods protocol-sigs)
+        signatures (protocol-methods protocol-sigs)
         fields (->> protocol-sigs keys (map (comp symbol name)))]
     `(defrecord ~record-name [~@fields]
        ~protocol
@@ -33,7 +32,7 @@
                   ((~(keyword name) ~(first args)) ~@args)))
               signatures))))
 
-(defmacro protocol-spy
+(defmacro spy
   "Generates a record implementing the protocol and creates a new instance
   of the record with the spies provided."
   [protocol & [spies]]
@@ -43,5 +42,5 @@
        (defspy ~rname ~protocol)
        (~(symbol (str 'map-> rname))
         ~(into {} (map (fn [[k v]]
-                         {k (get spies k '(spy/spy))})
+                         {k (get spies k '(spy.core/spy))})
                        signatures))))))

--- a/test/spy/protocols_test.clj
+++ b/test/spy/protocols_test.clj
@@ -1,12 +1,12 @@
 (ns spy.protocols-test
   (:require [clojure.test :refer [deftest is testing]]
             [spy.core :as spy]
-            [spy.alpha :as spy-alpha]))
+            [spy.protocol :as protocol]))
 
 (defprotocol Hello
   (hello [this]))
 
-(spy-alpha/defspy HelloSpy Hello)
+(protocol/defspy HelloSpy Hello)
 
 (deftest basic-test
   (let [pspy (map->HelloSpy {:hello (spy/stub :helloworld)})]
@@ -18,7 +18,7 @@
   (hello-one [this a])
   (hello-two [this b]))
 
-(spy-alpha/defspy HelloTwoSpy HelloTwo)
+(protocol/defspy HelloTwoSpy HelloTwo)
 
 (deftest hello-two-test
   (let [pspy (map->HelloTwoSpy {:hello-one (spy/stub :h1)
@@ -34,7 +34,7 @@
 (defprotocol HelloMulti
   (hello-multi [this] [this a]))
 
-(spy-alpha/defspy HelloMultiSpy HelloMulti)
+(protocol/defspy HelloMultiSpy HelloMulti)
 
 (deftest hello-multi-test
   (let [pspy (->HelloMultiSpy (spy/stub :hello-world))]
@@ -48,7 +48,7 @@
   (hello-multi2 [this] [this a])
   (something-else [this x]))
 
-(spy-alpha/defspy HelloMulti2Spy HelloMulti2)
+(protocol/defspy HelloMulti2Spy HelloMulti2)
 
 (deftest hello-multi2-test
   (let [pspy (->HelloMulti2Spy (spy/stub :helloworld) (spy/stub :something-else))]
@@ -64,7 +64,7 @@
   (basic-protocol [this]))
 
 (deftest basic-protocol-test
-  (let [pspy (spy-alpha/protocol-spy BasicProtocol)]
+  (let [pspy (protocol/spy BasicProtocol)]
     (is (satisfies? BasicProtocol pspy))
     (is (false? (spy/called-once? (:basic-protocol pspy))))
 
@@ -74,7 +74,7 @@
     (is (spy/called-once? (:basic-protocol pspy)))))
 
 (deftest protocol-with-custom-spy-test
-  (let [pspy (spy-alpha/protocol-spy BasicProtocol {:basic-protocol (spy/stub 99)})]
+  (let [pspy (protocol/spy BasicProtocol {:basic-protocol (spy/stub 99)})]
     (is (satisfies? BasicProtocol pspy))
     (is (= 99 (basic-protocol pspy)))
     (is (spy/called-once? (:basic-protocol pspy)))))

--- a/test/spy/protocols_test.clj
+++ b/test/spy/protocols_test.clj
@@ -6,7 +6,6 @@
 (defprotocol Hello
   (hello [this]))
 
-
 (defprotocol HelloTwo
   (hello-one [this a])
   (hello-two [this b]))
@@ -20,42 +19,46 @@
 
 (deftest basic-test
   (let [hello-spy (spy/stub :helloworld)
-        x (spy-alpha/protocol-spy Hello {:hello hello-spy})]
-    (is (satisfies? Hello x))
-    (hello x)
-    (spy/called-with? hello-spy x)))
+        proto-spy (spy-alpha/protocol-spy Hello {:hello hello-spy})]
+    (is (satisfies? Hello proto-spy))
+    (is (= [:hello] (keys (meta proto-spy))))
+    (hello proto-spy)
+    (spy/called-with? hello-spy proto-spy)))
 
 (deftest hello-two-test
   (let [first-spy (spy/stub :h1)
         second-spy (spy/stub :h2)
-        x (spy-alpha/protocol-spy HelloTwo {:hello-one first-spy
-                                            :hello-two second-spy})]
-    (is (satisfies? HelloTwo x))
+        proto-spy (spy-alpha/protocol-spy HelloTwo {:hello-one first-spy
+                                                    :hello-two second-spy})]
+    (is (satisfies? HelloTwo proto-spy))
+    (is (= [:hello-one :hello-two] (keys (meta proto-spy))))
 
-    (hello-one x :foo)
-    (is (spy/called-once-with? first-spy x :foo))
+    (hello-one proto-spy :foo)
+    (is (spy/called-once-with? first-spy proto-spy :foo))
 
-    (hello-two x :bar)
-    (is (spy/called-once-with? second-spy x :bar))))
+    (hello-two proto-spy :bar)
+    (is (spy/called-once-with? second-spy proto-spy :bar))))
 
 (deftest hello-multi-test
   (let [hello-spy (spy/stub :helloworld)
-        x (spy-alpha/protocol-spy HelloMulti {:hello-multi hello-spy})]
-    (is (satisfies? HelloMulti x))
-    (hello-multi x)
-    (hello-multi x :foo)
-    (spy/called-with? hello-spy x)
-    (spy/called-with? hello-spy x :foo)))
+        proto-spy (spy-alpha/protocol-spy HelloMulti {:hello-multi hello-spy})]
+    (is (satisfies? HelloMulti proto-spy))
+    (is (= [:hello-multi] (keys (meta proto-spy))))
+    (hello-multi proto-spy)
+    (hello-multi proto-spy :foo)
+    (spy/called-with? hello-spy proto-spy)
+    (spy/called-with? hello-spy proto-spy :foo)))
 
 (deftest hello-multi2-test
   (let [hello-spy (spy/stub :helloworld)
         se-spy (spy/stub :something-else)
-        x (spy-alpha/protocol-spy HelloMulti2 {:hello-multi2 hello-spy
-                                               :something-else se-spy})]
-    (is (satisfies? HelloMulti2 x))
-    (hello-multi2 x)
-    (hello-multi2 x :foo)
-    (something-else x :bingo)
-    (spy/called-with? hello-spy x)
-    (spy/called-with? hello-spy x :foo)
-    (spy/called-with? se-spy x :bingo)))
+        proto-spy (spy-alpha/protocol-spy HelloMulti2 {:hello-multi2 hello-spy
+                                                       :something-else se-spy})]
+    (is (satisfies? HelloMulti2 proto-spy))
+    (is (= [:hello-multi2 :something-else] (keys (meta proto-spy))))
+    (hello-multi2 proto-spy)
+    (hello-multi2 proto-spy :foo)
+    (something-else proto-spy :bingo)
+    (spy/called-with? hello-spy proto-spy)
+    (spy/called-with? hello-spy proto-spy :foo)
+    (spy/called-with? se-spy proto-spy :bingo)))

--- a/test/spy/protocols_test.clj
+++ b/test/spy/protocols_test.clj
@@ -1,0 +1,61 @@
+(ns spy.protocols-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [spy.core :as spy]
+            [spy.alpha :as spy-alpha]))
+
+(defprotocol Hello
+  (hello [this]))
+
+
+(defprotocol HelloTwo
+  (hello-one [this a])
+  (hello-two [this b]))
+
+(defprotocol HelloMulti
+  (hello-multi [this] [this a]))
+
+(defprotocol HelloMulti2
+  (hello-multi2 [this] [this a])
+  (something-else [this x]))
+
+(deftest basic-test
+  (let [hello-spy (spy/stub :helloworld)
+        x (spy-alpha/protocol-spy Hello {:hello hello-spy})]
+    (is (satisfies? Hello x))
+    (hello x)
+    (spy/called-with? hello-spy x)))
+
+(deftest hello-two-test
+  (let [first-spy (spy/stub :h1)
+        second-spy (spy/stub :h2)
+        x (spy-alpha/protocol-spy HelloTwo {:hello-one first-spy
+                                      :hello-two second-spy})]
+    (is (satisfies? HelloTwo x))
+
+    (hello-one x :foo)
+    (is (spy/called-once-with? first-spy x :foo))
+
+    (hello-two x :bar)
+    (is (spy/called-once-with? second-spy x :bar))))
+
+(deftest hello-multi-test
+  (let [hello-spy (spy/stub :helloworld)
+        x (spy-alpha/protocol-spy HelloMulti {:hello-multi hello-spy})]
+    (is (satisfies? HelloMulti x))
+    (hello-multi x)
+    (hello-multi x :foo)
+    (spy/called-with? hello-spy x)
+    (spy/called-with? hello-spy x :foo)))
+
+(deftest hello-multi2-test
+  (let [hello-spy (spy/stub :helloworld)
+        se-spy (spy/stub :something-else)
+        x (spy-alpha/protocol-spy HelloMulti2 {:hello-multi2 hello-spy
+                                         :something-else se-spy})]
+    (is (satisfies? HelloMulti2 x))
+    (hello-multi2 x)
+    (hello-multi2 x :foo)
+    (something-else x :bingo)
+    (spy/called-with? hello-spy x)
+    (spy/called-with? hello-spy x :foo)
+    (spy/called-with? se-spy x :bingo)))

--- a/test/spy/protocols_test.clj
+++ b/test/spy/protocols_test.clj
@@ -29,7 +29,7 @@
   (let [first-spy (spy/stub :h1)
         second-spy (spy/stub :h2)
         x (spy-alpha/protocol-spy HelloTwo {:hello-one first-spy
-                                      :hello-two second-spy})]
+                                            :hello-two second-spy})]
     (is (satisfies? HelloTwo x))
 
     (hello-one x :foo)
@@ -51,7 +51,7 @@
   (let [hello-spy (spy/stub :helloworld)
         se-spy (spy/stub :something-else)
         x (spy-alpha/protocol-spy HelloMulti2 {:hello-multi2 hello-spy
-                                         :something-else se-spy})]
+                                               :something-else se-spy})]
     (is (satisfies? HelloMulti2 x))
     (hello-multi2 x)
     (hello-multi2 x :foo)

--- a/test/spy/protocols_test.clj
+++ b/test/spy/protocols_test.clj
@@ -59,3 +59,22 @@
     (spy/called-with? (:hello-multi2 pspy) pspy)
     (spy/called-with? (:hello-multi2 pspy) pspy :foo)
     (spy/called-with? (:something-else pspy) pspy :bingo)))
+
+(defprotocol BasicProtocol
+  (basic-protocol [this]))
+
+(deftest basic-protocol-test
+  (let [pspy (spy-alpha/protocol-spy BasicProtocol)]
+    (is (satisfies? BasicProtocol pspy))
+    (is (false? (spy/called-once? (:basic-protocol pspy))))
+
+    (testing "defaults to an empty spy (that returns nil when called)"
+      (is (nil? (basic-protocol pspy))))
+
+    (is (spy/called-once? (:basic-protocol pspy)))))
+
+(deftest protocol-with-custom-spy-test
+  (let [pspy (spy-alpha/protocol-spy BasicProtocol {:basic-protocol (spy/stub 99)})]
+    (is (satisfies? BasicProtocol pspy))
+    (is (= 99 (basic-protocol pspy)))
+    (is (spy/called-once? (:basic-protocol pspy)))))

--- a/test/spy/protocols_test.clj
+++ b/test/spy/protocols_test.clj
@@ -6,59 +6,56 @@
 (defprotocol Hello
   (hello [this]))
 
+(spy-alpha/defspy HelloSpy Hello)
+
+(deftest basic-test
+  (let [pspy (map->HelloSpy {:hello (spy/stub :helloworld)})]
+    (is (satisfies? Hello pspy))
+    (hello pspy)
+    (spy/called-with? (:hello pspy) pspy)))
+
 (defprotocol HelloTwo
   (hello-one [this a])
   (hello-two [this b]))
 
+(spy-alpha/defspy HelloTwoSpy HelloTwo)
+
+(deftest hello-two-test
+  (let [pspy (map->HelloTwoSpy {:hello-one (spy/stub :h1)
+                                :hello-two (spy/stub :h2)})]
+    (is (satisfies? HelloTwo pspy))
+
+    (hello-one pspy :foo)
+    (is (spy/called-once-with? (:hello-one pspy) pspy :foo))
+
+    (hello-two pspy :bar)
+    (is (spy/called-once-with? (:hello-two pspy) pspy :bar))))
+
 (defprotocol HelloMulti
   (hello-multi [this] [this a]))
+
+(spy-alpha/defspy HelloMultiSpy HelloMulti)
+
+(deftest hello-multi-test
+  (let [pspy (->HelloMultiSpy (spy/stub :hello-world))]
+    (is (satisfies? HelloMulti pspy))
+    (hello-multi pspy)
+    (hello-multi pspy :foo)
+    (spy/called-with? (:hello-multi pspy) pspy)
+    (spy/called-with? (:hello-multi pspy) pspy :foo)))
 
 (defprotocol HelloMulti2
   (hello-multi2 [this] [this a])
   (something-else [this x]))
 
-(deftest basic-test
-  (let [hello-spy (spy/stub :helloworld)
-        proto-spy (spy-alpha/protocol-spy Hello {:hello hello-spy})]
-    (is (satisfies? Hello proto-spy))
-    (is (= [:hello] (keys (meta proto-spy))))
-    (hello proto-spy)
-    (spy/called-with? hello-spy proto-spy)))
-
-(deftest hello-two-test
-  (let [first-spy (spy/stub :h1)
-        second-spy (spy/stub :h2)
-        proto-spy (spy-alpha/protocol-spy HelloTwo {:hello-one first-spy
-                                                    :hello-two second-spy})]
-    (is (satisfies? HelloTwo proto-spy))
-    (is (= [:hello-one :hello-two] (keys (meta proto-spy))))
-
-    (hello-one proto-spy :foo)
-    (is (spy/called-once-with? first-spy proto-spy :foo))
-
-    (hello-two proto-spy :bar)
-    (is (spy/called-once-with? second-spy proto-spy :bar))))
-
-(deftest hello-multi-test
-  (let [hello-spy (spy/stub :helloworld)
-        proto-spy (spy-alpha/protocol-spy HelloMulti {:hello-multi hello-spy})]
-    (is (satisfies? HelloMulti proto-spy))
-    (is (= [:hello-multi] (keys (meta proto-spy))))
-    (hello-multi proto-spy)
-    (hello-multi proto-spy :foo)
-    (spy/called-with? hello-spy proto-spy)
-    (spy/called-with? hello-spy proto-spy :foo)))
+(spy-alpha/defspy HelloMulti2Spy HelloMulti2)
 
 (deftest hello-multi2-test
-  (let [hello-spy (spy/stub :helloworld)
-        se-spy (spy/stub :something-else)
-        proto-spy (spy-alpha/protocol-spy HelloMulti2 {:hello-multi2 hello-spy
-                                                       :something-else se-spy})]
-    (is (satisfies? HelloMulti2 proto-spy))
-    (is (= [:hello-multi2 :something-else] (keys (meta proto-spy))))
-    (hello-multi2 proto-spy)
-    (hello-multi2 proto-spy :foo)
-    (something-else proto-spy :bingo)
-    (spy/called-with? hello-spy proto-spy)
-    (spy/called-with? hello-spy proto-spy :foo)
-    (spy/called-with? se-spy proto-spy :bingo)))
+  (let [pspy (->HelloMulti2Spy (spy/stub :helloworld) (spy/stub :something-else))]
+    (is (satisfies? HelloMulti2 pspy))
+    (hello-multi2 pspy)
+    (hello-multi2 pspy :foo)
+    (something-else pspy :bingo)
+    (spy/called-with? (:hello-multi2 pspy) pspy)
+    (spy/called-with? (:hello-multi2 pspy) pspy :foo)
+    (spy/called-with? (:something-else pspy) pspy :bingo)))


### PR DESCRIPTION
 #2 Initial work for Protocol support - currently Clojure only as ClojureScript macros need to get the list of methods on a protocol in a different way.
