### PR TITLE
Protocols using reify

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ If you're testing synchronous code then you can replace functions using [with-re
 
 ### Spying on Protocols (Experimental)
 
-Currently only Clojure is supported, I intend to make this work for ClojureScript too but it's a little trickier. There is also the caveat that **the protocol must be referred for this to work, it cannot be referenced from another namespace e.g. ns/Repository**. I'm open to suggestions on how to improve this and support ClojureScript, all contributions are welcome!
+Currently only Clojure is supported, I intend to make this work for ClojureScript too but it's a little trickier. I'm open to suggestions on how to improve this and support ClojureScript, all contributions are welcome!
 
 To create a spy of a protocol you need to refer the protocol and bring in the ```spy.protocol``` namespace. The easiest implementation is to call ```(protocol/spy MyProtocol)``` which will define a record that implements every method of the protocol, and provides a basic spy for each method that returns ```nil```.
 
@@ -223,12 +223,12 @@ To create a spy of a protocol you need to refer the protocol and bring in the ``
     (is (satisfies? BasicProtocol pspy))
 
     ;; make an assertion on the spy for the `basic-protocol` method
-    (is (false? (spy/called-once? (:basic-protocol pspy))))
+    (is (false? (spy/called-once? (:basic-protocol (protocol/spies pspy)))))
 
     ;; the default spy returns nil when called
     (is (nil? (basic-protocol pspy)))
 
-    (is (spy/called-once? (:basic-protocol pspy)))))
+    (is (spy/called-once? (:basic-protocol (protocol/spies pspy))))))
 ```
 
 You can provide your own spies for a protocol by passing in a map of spies with the method name as the key. You only need to provide the methods that you want to override, if the protocol has 5 methods and you only provide 1 in your map then the other 4 will be default spies that return nil.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ You can provide your own spies for a protocol by passing in a map of spies with 
   (let [pspy (protocol/spy BasicProtocol {:basic-protocol (spy/stub 99)})]
     (is (satisfies? BasicProtocol pspy))
     (is (= 99 (basic-protocol pspy)))
-    (is (spy/called-once? (:basic-protocol pspy)))))
+    (is (spy/called-once? (:basic-protocol (protocol/spies pspy))))))
 ```
 
 ## Contributing

--- a/test/clj/spy/my_protocol.clj
+++ b/test/clj/spy/my_protocol.clj
@@ -1,0 +1,4 @@
+(ns spy.my-protocol)
+
+(defprotocol MyProtocolInADifferentNs
+  (hello-from-different-ns [this]))

--- a/test/clj/spy/protocols_test.clj
+++ b/test/clj/spy/protocols_test.clj
@@ -1,64 +1,54 @@
 (ns spy.protocols-test
   (:require [clojure.test :refer [deftest is testing]]
             [spy.core :as spy]
-            [spy.protocol :as protocol]))
+            [spy.protocol :as protocol]
+            [spy.my-protocol :as my-protocol]))
 
 (defprotocol Hello
   (hello [this]))
-
-(protocol/defspy HelloSpy Hello)
-
-(deftest basic-test
-  (let [pspy (map->HelloSpy {:hello (spy/stub :helloworld)})]
-    (is (satisfies? Hello pspy))
-    (hello pspy)
-    (spy/called-with? (:hello pspy) pspy)))
 
 (defprotocol HelloTwo
   (hello-one [this a])
   (hello-two [this b]))
 
-(protocol/defspy HelloTwoSpy HelloTwo)
-
 (deftest hello-two-test
-  (let [pspy (map->HelloTwoSpy {:hello-one (spy/stub :h1)
-                                :hello-two (spy/stub :h2)})]
+  (let [pspy (protocol/spy HelloTwo
+                           {:hello-one (spy/stub :h1)
+                            :hello-two (spy/stub :h2)})]
     (is (satisfies? HelloTwo pspy))
 
     (hello-one pspy :foo)
-    (is (spy/called-once-with? (:hello-one pspy) pspy :foo))
+    (is (spy/called-once-with? (:hello-one (protocol/spies pspy)) pspy :foo))
 
     (hello-two pspy :bar)
-    (is (spy/called-once-with? (:hello-two pspy) pspy :bar))))
+    (is (spy/called-once-with? (:hello-two (protocol/spies pspy)) pspy :bar))))
 
 (defprotocol HelloMulti
   (hello-multi [this] [this a]))
 
-(protocol/defspy HelloMultiSpy HelloMulti)
-
 (deftest hello-multi-test
-  (let [pspy (->HelloMultiSpy (spy/stub :hello-world))]
+  (let [pspy (protocol/spy HelloMulti (spy/stub :hello-world))]
     (is (satisfies? HelloMulti pspy))
     (hello-multi pspy)
     (hello-multi pspy :foo)
-    (spy/called-with? (:hello-multi pspy) pspy)
-    (spy/called-with? (:hello-multi pspy) pspy :foo)))
+    (spy/called-with? (:hello-multi (protocol/spies pspy)) pspy)
+    (spy/called-with? (:hello-multi (protocol/spies pspy)) pspy :foo)))
 
 (defprotocol HelloMulti2
   (hello-multi2 [this] [this a])
   (something-else [this x]))
 
-(protocol/defspy HelloMulti2Spy HelloMulti2)
-
 (deftest hello-multi2-test
-  (let [pspy (->HelloMulti2Spy (spy/stub :helloworld) (spy/stub :something-else))]
+  (let [pspy (protocol/spy HelloMulti2
+                           {:hello-multi2 (spy/stub :helloworld)
+                            :something-else (spy/stub :something-else)})]
     (is (satisfies? HelloMulti2 pspy))
     (hello-multi2 pspy)
     (hello-multi2 pspy :foo)
     (something-else pspy :bingo)
-    (spy/called-with? (:hello-multi2 pspy) pspy)
-    (spy/called-with? (:hello-multi2 pspy) pspy :foo)
-    (spy/called-with? (:something-else pspy) pspy :bingo)))
+    (spy/called-with? (:hello-multi2 (protocol/spies pspy)) pspy)
+    (spy/called-with? (:hello-multi2 (protocol/spies pspy)) pspy :foo)
+    (spy/called-with? (:something-else (protocol/spies pspy)) pspy :bingo)))
 
 (defprotocol BasicProtocol
   (basic-protocol [this]))
@@ -71,10 +61,17 @@
     (testing "defaults to an empty spy (that returns nil when called)"
       (is (nil? (basic-protocol pspy))))
 
-    (is (spy/called-once? (:basic-protocol pspy)))))
+    (is (spy/called-once? (:basic-protocol (protocol/spies pspy))))))
 
-(deftest protocol-with-custom-spy-test
+(deftest protocol-with-custom-spy-test2
   (let [pspy (protocol/spy BasicProtocol {:basic-protocol (spy/stub 99)})]
     (is (satisfies? BasicProtocol pspy))
     (is (= 99 (basic-protocol pspy)))
-    (is (spy/called-once? (:basic-protocol pspy)))))
+    (is (spy/called-once? (:basic-protocol (protocol/spies pspy))))))
+
+(deftest protocol-with-custom-spy-test2-different-ns
+  (let [pspy (protocol/spy my-protocol/MyProtocolInADifferentNs
+                            {:hello-from-different-ns (spy/stub 42)})]
+    (is (satisfies? my-protocol/MyProtocolInADifferentNs pspy))
+    (is (= 42 (my-protocol/hello-from-different-ns pspy)))
+    (is (spy/called-once? (:hello-from-different-ns (protocol/spies pspy))))))


### PR DESCRIPTION
Fixes #6 

Spies are now stored as metadata on the instance of the protocol created via `reify`. Introduced `protocol/spies` function to simplify access to spies.