### PR TITLE
Implement spy `assert-expr`s for clojure.test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It records calls and responses to and from a function, allowing you to verify in
 ```clojure
 (require '[spy.core :as spy]       ;; the core library with functions returning booleans
          '[spy.assert :as assert]  ;; assertions wrapping clojure.test/is
+         '[spy.test]               ;; assert-expr definitions for clojure.test
          '[clojure.test :refer [testing is]])
 
 (defn adder [x y] (+ x y))
@@ -74,6 +75,10 @@ It records calls and responses to and from a function, allowing you to verify in
 
 (testing "but spy.assert gives us better error messages when our assertions don't hold true"
   (assert/called-with? spy-adder 66 99))
+
+(testing "spy defines assert-expr for core spy verification"
+  (is (spy/called? spy-adder))
+  (is (spy/called-with? spy-adder 66 99)))
 
 ;; FAIL in () (form-init15061478131364358.clj:197)
 ;; assert gives us better error messages when our assertions don't hold true

--- a/src/clj/spy/test.clj
+++ b/src/clj/spy/test.clj
@@ -44,7 +44,7 @@
   [msg form]
   `(assert-called ~msg ~form ~identity ~spy/call-count))
 
-(defmacro assert-called-1
+(defmacro assert-called-once
   [msg form]
   `(assert-called ~msg ~form ~(fn [] 1) ~spy/call-count))
 
@@ -62,7 +62,7 @@
 
 (defmethod t/assert-expr 'spy/called-once?
   [msg form]
-  `(assert-called-1 ~msg ~form))
+  `(assert-called-once ~msg ~form))
 
 (defmethod t/assert-expr 'spy/called-with?
   [msg form]
@@ -82,11 +82,11 @@
 
 (defmethod t/assert-expr 'spy/called?
   [msg form]
-  `(assert-called-1 ~msg ~form))
+  `(assert-called-once ~msg ~form))
 
 (defmethod t/assert-expr 'spy/called-at-least-once?
   [msg form]
-  `(assert-called-1 ~msg ~form))
+  `(assert-called-once ~msg ~form))
 
 (defmethod t/assert-expr 'spy/called-no-more-than-n-times?
   [msg form]
@@ -94,4 +94,4 @@
 
 (defmethod t/assert-expr 'spy/called-no-more-than-once?
   [msg form]
-  `(assert-called-1 ~msg ~form))
+  `(assert-called-once ~msg ~form))

--- a/src/clj/spy/test.clj
+++ b/src/clj/spy/test.clj
@@ -1,0 +1,97 @@
+(ns spy.test
+  "Implements the `clojure.test/assert-expr` multimethod for all spy predicates,
+  allowing for rich error reporting without having to wrap `clojure.test/is`.
+
+  Example usage:
+
+  (def f (spy/spy))
+
+  (f \"foo\" \"bar\")
+
+  ;; succeeds!
+  (is (spy/called-with? f \"foo\" \"bar\")
+
+  ;; fails with:
+  ;; FAIL in () (form-init541289308750557841.clj:234)
+  ;; expected: (\"baz\")
+  ;;   actual: [(\"foo\" \"bar\")]
+  (is (spy/called-with? f \"baz\"))"
+  (:require [clojure.test :as t]
+            [spy.core :as spy]))
+
+(defn assert-called*
+  [msg expected-fn actual-fn spy-fn args]
+  (let [result (apply spy-fn args)]
+    (t/do-report {:type     (if result :pass :fail)
+                  :message  msg
+                  :expected (apply expected-fn (rest args))
+                  :actual   (actual-fn (first args))})
+    result))
+
+(defn resolve-spy-fn
+  [expr]
+  (let [ns-sym 'spy.core]
+    (require ns-sym)
+    (ns-resolve (the-ns ns-sym) (symbol (name expr)))))
+
+(defmacro assert-called
+  [msg form expected-fn actual-fn]
+  (let [spy-fn (resolve-spy-fn (first form))
+        args   (rest form)]
+    `(assert-called* ~msg ~expected-fn ~actual-fn ~spy-fn (list ~@args))))
+
+(defmacro assert-called-n
+  [msg form]
+  `(assert-called ~msg ~form ~identity ~spy/call-count))
+
+(defmacro assert-called-1
+  [msg form]
+  `(assert-called ~msg ~form ~(fn [] 1) ~spy/call-count))
+
+(defmacro assert-called-args
+  [msg form]
+  `(assert-called ~msg ~form ~(fn [& args] args) ~spy/calls))
+
+(defmethod t/assert-expr 'spy/called-n-times?
+  [msg form]
+  `(assert-called-n ~msg ~form))
+
+(defmethod t/assert-expr 'spy/not-called?
+  [msg form]
+  `(assert-called ~msg ~form ~(fn [] 0) ~spy/call-count))
+
+(defmethod t/assert-expr 'spy/called-once?
+  [msg form]
+  `(assert-called-1 ~msg ~form))
+
+(defmethod t/assert-expr 'spy/called-with?
+  [msg form]
+  `(assert-called-args ~msg ~form))
+
+(defmethod t/assert-expr 'spy/not-called-with?
+  [msg form]
+  `(assert-called-args ~msg ~form))
+
+(defmethod t/assert-expr 'spy/called-once-with?
+  [msg form]
+  `(assert-called-args ~msg ~form))
+
+(defmethod t/assert-expr 'spy/called-at-least-n-times?
+  [msg form]
+  `(assert-called-n ~msg ~form))
+
+(defmethod t/assert-expr 'spy/called?
+  [msg form]
+  `(assert-called-1 ~msg ~form))
+
+(defmethod t/assert-expr 'spy/called-at-least-once?
+  [msg form]
+  `(assert-called-1 ~msg ~form))
+
+(defmethod t/assert-expr 'spy/called-no-more-than-n-times?
+  [msg form]
+  `(assert-called-n ~msg ~form))
+
+(defmethod t/assert-expr 'spy/called-no-more-than-once?
+  [msg form]
+  `(assert-called-1 ~msg ~form))

--- a/test/clj/spy/test_test.clj
+++ b/test/clj/spy/test_test.clj
@@ -1,0 +1,173 @@
+(ns spy.test-test
+  (:require [clojure.test :as t :refer [is deftest]]
+            [spy.core :as spy]
+            [spy.test]))
+
+(defn check
+  [status assert-fn check-fn]
+  (let [reporter (spy/spy)]
+     (binding [t/report reporter]
+       (assert-fn))
+     (let [report (first (spy/first-call reporter))]
+       (is (= status (:type report)))
+       (check-fn report))))
+
+(defn check-simple
+  [status assert-fn expected actual]
+  (check status assert-fn (fn [report]
+                            (is (= expected (:expected report)))
+                            (is (= actual (:actual report))))))
+
+(defn passes
+  [assert-fn expected actual]
+  (check-simple :pass assert-fn expected actual))
+
+(defn fails
+  [assert-fn expected actual]
+  (check-simple :fail assert-fn expected actual))
+
+(defn errors
+  [assert-fn message]
+  (check :error
+         assert-fn
+         (fn [report]
+           (is (= message (-> report :actual .getMessage))))))
+
+(deftest called-n-times?-test
+  (let [f (spy/spy)]
+    (passes #(is (spy/called-n-times? f 0)) 0 0)
+
+    (fails #(is (spy/called-n-times? f 5)) 5 0))
+
+  (errors
+   #(is (spy/called-n-times?))
+   "Wrong number of args (0) passed to: core/called-n-times?"))
+
+(deftest not-called?-test
+  (let [f (spy/spy)]
+    (passes #(is (spy/not-called? f)) 0 0)
+
+    (f)
+    (fails #(is (spy/not-called? f)) 0 1))
+
+  (errors
+   #(is (spy/not-called?))
+   "Wrong number of args (0) passed to: core/not-called?"))
+
+(deftest called-once?-test
+  (let [f (spy/spy)]
+    (fails #(is (spy/called-once? f)) 1 0)
+
+    (f)
+    (passes #(is (spy/called-once? f)) 1 1))
+
+  (errors
+   #(is (spy/called-once?))
+   "Wrong number of args (0) passed to: core/called-once?"))
+
+(deftest called-with?-test
+  (let [f (spy/spy)]
+    (fails #(is (spy/called-with? f "foo" "bar")) ["foo" "bar"] [])
+
+    (f "foo" "bar")
+    (passes
+     #(is (spy/called-with? f "foo" "bar")) ["foo" "bar"] [["foo" "bar"]]))
+
+  (errors #(is (spy/called-with?))
+          "Wrong number of args (0) passed to: core/called-with?"))
+
+(deftest not-called-with?-test
+  (let [f (spy/spy)]
+    (passes #(is (spy/not-called-with? f "foo" "bar")) ["foo" "bar"] [])
+
+    (f "foo" "bar")
+    (fails #(is (spy/not-called-with? f "foo" "bar"))
+           ["foo" "bar"]
+           [["foo" "bar"]]))
+
+  (errors #(is (spy/not-called-with?))
+          "Wrong number of args (0) passed to: core/not-called-with?"))
+
+(deftest called-once-with?-test
+  (let [f (spy/spy)]
+    (fails #(is (spy/called-once-with? f "foo" "bar")) ["foo" "bar"] [])
+
+    (f "foo" "bar")
+    (passes
+     #(is (spy/called-once-with? f "foo" "bar")) ["foo" "bar"] [["foo" "bar"]])
+
+    (f "foo" "bar")
+    (fails #(is (spy/called-once-with? f "foo" "bar"))
+           ["foo" "bar"]
+           [["foo" "bar"] ["foo" "bar"]]))
+
+  (errors #(is (spy/called-once-with?))
+          "Wrong number of args (0) passed to: core/called-once-with?"))
+
+(deftest called-at-least-n-times?-test
+  (let [f (spy/spy)]
+    (fails #(is (spy/called-at-least-n-times? f 2)) 2 0)
+
+    (f)
+    (fails #(is (spy/called-at-least-n-times? f 2)) 2 1)
+
+    (f)
+    (passes #(is (spy/called-at-least-n-times? f 2)) 2 2))
+
+  (errors
+   #(is (spy/called-at-least-n-times?))
+   "Wrong number of args (0) passed to: core/called-at-least-n-times?"))
+
+(deftest called?-test
+  (let [f (spy/spy)]
+    (fails #(is (spy/called? f)) 1 0)
+
+    (f)
+    (passes #(is (spy/called? f)) 1 1)
+
+    (f)
+    (passes #(is (spy/called? f)) 1 2))
+
+  (errors #(is (spy/called?))
+          "Wrong number of args (0) passed to: core/called?"))
+
+(deftest called-at-least-once?-test
+  (let [f (spy/spy)]
+    (fails #(is (spy/called-at-least-once? f)) 1 0)
+
+    (f)
+    (passes #(is (spy/called-at-least-once? f)) 1 1)
+
+    (f)
+    (passes #(is (spy/called-at-least-once? f)) 1 2))
+
+  (errors #(is (spy/called-at-least-once?))
+          "Wrong number of args (0) passed to: core/called-at-least-once?"))
+
+(deftest called-no-more-than-n-times?-test
+  (let [f (spy/spy)]
+    (passes #(is (spy/called-no-more-than-n-times? f 1)) 1 0)
+
+    (f)
+    (passes #(is (spy/called-no-more-than-n-times? f 1)) 1 1)
+
+    (f)
+    (fails #(is (spy/called-no-more-than-n-times? f 1)) 1 2))
+
+  (errors
+   #(is (spy/called-no-more-than-n-times?))
+   "Wrong number of args (0) passed to: core/called-no-more-than-n-times?"))
+
+(deftest called-no-more-than-once?-test
+  (let [f (spy/spy)]
+    (passes #(is (spy/called-no-more-than-once? f)) 1 0)
+
+    (f)
+    (passes #(is (spy/called-no-more-than-once? f)) 1 1)
+
+    (f)
+    (fails #(is (spy/called-no-more-than-once? f)) 1 2))
+
+  (errors
+   #(is (spy/called-no-more-than-once?))
+   "Wrong number of args (0) passed to: core/called-no-more-than-once?"))


### PR DESCRIPTION
Implements the `clojure.test/assert-expr` multimethod for all spy predicates, allowing for rich error reporting without having to wrap `clojure.test/is`.

Example usage:

```clojure
(def f (spy/spy))

(f "foo" "bar")

;; succeeds
(is (spy/called-with? f "foo" "bar")

;; fails with
;; expected: ("baz")
;;   actual: [("foo" "bar")]
(is (spy/called-with? f "baz"))
```

Notably, this does not include a matching implementation for ClojureScript due to the complexities around CLJS macros, but this could be a good starting point for an implementation for CLJS.

I've updated the README and ensured that the tests pass. What do you think about setting up CircleCI for this project?

Resolves #15.