### PR TITLE
Ensure spy.core is required in test.cljc

### DIFF
--- a/src/cljc/spy/test.cljc
+++ b/src/cljc/spy/test.cljc
@@ -17,7 +17,8 @@
   ;;   actual: [(\"foo\" \"bar\")]
   (is (spy/called-with? f \"baz\"))"
   #?(:cljs (:require-macros [spy.test.cljs])
-     :clj  (:require [clojure.test :as t])))
+     :clj  (:require [clojure.test :as t]))
+  (:require [spy.core]))
 
 (defn called-n [n] n)
 (defn called-once [] 1)

--- a/src/cljc/spy/test.cljc
+++ b/src/cljc/spy/test.cljc
@@ -41,19 +41,19 @@
 
      (defmacro assert-called-n
        [msg form report-fn]
-       `(assert-called ~msg ~form ~report-fn called-n spy/call-count))
+       `(assert-called ~msg ~form ~report-fn called-n spy.core/call-count))
 
      (defmacro assert-called-once
        [msg form report-fn]
-       `(assert-called ~msg ~form ~report-fn called-once spy/call-count))
+       `(assert-called ~msg ~form ~report-fn called-once spy.core/call-count))
 
      (defmacro assert-called-args
        [msg form report-fn]
-       `(assert-called ~msg ~form ~report-fn called-args spy/calls))
+       `(assert-called ~msg ~form ~report-fn called-args spy.core/calls))
 
      (defmacro assert-not-called
        [msg form report-fn]
-       `(assert-called ~msg ~form ~report-fn not-called spy/call-count))
+       `(assert-called ~msg ~form ~report-fn not-called spy.core/call-count))
 
      (defmethod t/assert-expr 'spy/called-n-times?
        [msg form]


### PR DESCRIPTION
Shouldn't matter once the namespaces are merged. Doing this just out of paranoia.