### PR TITLE
Implement missing call-matching? expr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 ---
 os: linux
 dist: xenial
+language: clojure
+lein: 2.9.3
+cache:
+  directories:
+    - "$HOME/.m2"
 jobs:
   include:
-    - language: clojure
-      lein: 2.9.3
-      script: lein test
+    - script: lein test
     - language: node_js
       node_js: lts/*
       script: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.4.0] - Unreleased
+- `assert-expr` implementation for `spy.core/call-matching?`.
+
+## [2.3.0] - 2020-11-17
+- Miscellaneous improvements and bugfixes in Clojure and ClojureScript `assert-expr` implementations.
+- Modernized ClojureScript build with `shadow-cljs`.
+
 ## [2.2.0] - 2020-11-16
 - Rich assertions for Clojure and ClojureScript, you can now require `spy.test` to register spy functions with `clojure.test/assert-expr` resulting in better error messages. This can be used instead of `spy.assert` which will likely be deprecated in the longer term in favour of `assert-expr`.
 

--- a/src/cljc/spy/test.cljc
+++ b/src/cljc/spy/test.cljc
@@ -50,6 +50,14 @@
   [calls]
   (actual-called-n-times calls))
 
+(defn expected-call-matching
+  [form]
+  form)
+
+(defn actual-call-matching
+  [calls]
+  (actual-called-with-args calls))
+
 #?(:clj
    (do
      (defmacro assert-called
@@ -96,46 +104,59 @@
                         ~`expected-not-called
                         ~`actual-not-called))
 
+     (defmacro assert-call-matching
+       [msg form report-fn]
+       `(assert-called ~msg
+                       ~form
+                       ~report-fn
+                       (fn [~'& ~'args]
+                         (expected-call-matching '~(last form)))
+                       ~`actual-call-matching))
+
      (defmethod t/assert-expr 'spy/called-n-times?
        [msg form]
-       `(assert-called-n-times ~msg ~form t/do-report))
+       `(assert-called-n-times ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/not-called?
        [msg form]
-       `(assert-not-called ~msg ~form t/do-report))
+       `(assert-not-called ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/called-once?
        [msg form]
-       `(assert-called-once ~msg ~form t/do-report))
+       `(assert-called-once ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/called-with?
        [msg form]
-       `(assert-called-with-args ~msg ~form t/do-report))
+       `(assert-called-with-args ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/not-called-with?
        [msg form]
-       `(assert-called-with-args ~msg ~form t/do-report))
+       `(assert-called-with-args ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/called-once-with?
        [msg form]
-       `(assert-called-with-args ~msg ~form t/do-report))
+       `(assert-called-with-args ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/called-at-least-n-times?
        [msg form]
-       `(assert-called-n-times ~msg ~form t/do-report))
+       `(assert-called-n-times ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/called?
        [msg form]
-       `(assert-called-once ~msg ~form t/do-report))
+       `(assert-called-once ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/called-at-least-once?
        [msg form]
-       `(assert-called-once ~msg ~form t/do-report))
+       `(assert-called-once ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/called-no-more-than-n-times?
        [msg form]
-       `(assert-called-n-times ~msg ~form t/do-report))
+       `(assert-called-n-times ~msg ~form ~`t/do-report))
 
      (defmethod t/assert-expr 'spy/called-no-more-than-once?
        [msg form]
-       `(assert-called-once ~msg ~form t/do-report))))
+       `(assert-called-once ~msg ~form ~`t/do-report))
+
+     (defmethod t/assert-expr 'spy/call-matching?
+       [msg form]
+       `(assert-call-matching ~msg ~form ~`t/do-report))))

--- a/src/cljs/spy/test/cljs.clj
+++ b/src/cljs/spy/test/cljs.clj
@@ -3,48 +3,53 @@
             [spy.test :refer [assert-called-n-times
                               assert-not-called
                               assert-called-once
-                              assert-called-with-args]]))
+                              assert-called-with-args
+                              assert-call-matching]]))
 
 (defmethod t/assert-expr 'spy/called-n-times?
   [_menv msg form]
-  `(assert-called-n-times ~msg ~form t/do-report))
+  `(assert-called-n-times ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/not-called?
   [_menv msg form]
-  `(assert-not-called ~msg ~form t/do-report))
+  `(assert-not-called ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/called-once?
   [_menv msg form]
-  `(assert-called-once ~msg ~form t/do-report))
+  `(assert-called-once ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/called-with?
   [_menv msg form]
-  `(assert-called-with-args ~msg ~form t/do-report))
+  `(assert-called-with-args ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/not-called-with?
   [_menv msg form]
-  `(assert-called-with-args ~msg ~form t/do-report))
+  `(assert-called-with-args ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/called-once-with?
   [_menv msg form]
-  `(assert-called-with-args ~msg ~form t/do-report))
+  `(assert-called-with-args ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/called-at-least-n-times?
   [_menv msg form]
-  `(assert-called-n-times ~msg ~form t/do-report))
+  `(assert-called-n-times ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/called?
   [_menv msg form]
-  `(assert-called-once ~msg ~form t/do-report))
+  `(assert-called-once ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/called-at-least-once?
   [_menv msg form]
-  `(assert-called-once ~msg ~form t/do-report))
+  `(assert-called-once ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/called-no-more-than-n-times?
   [_menv msg form]
-  `(assert-called-n-times ~msg ~form t/do-report))
+  `(assert-called-n-times ~msg ~form ~`t/do-report))
 
 (defmethod t/assert-expr 'spy/called-no-more-than-once?
   [_menv msg form]
-  `(assert-called-once ~msg ~form t/do-report))
+  `(assert-called-once ~msg ~form ~`t/do-report))
+
+(defmethod t/assert-expr 'spy/call-matching?
+  [_menv msg form]
+  `(assert-call-matching ~msg ~form ~`t/do-report))

--- a/test/cljc/spy/core_test.cljc
+++ b/test/cljc/spy/core_test.cljc
@@ -319,6 +319,22 @@
     (f)
     (fails-expr #(is (spy/called-no-more-than-once? f)) 1 2)))
 
+(deftest call-matching?-expr-test
+  (let [f (spy/spy)]
+    (fails-expr #(is (spy/call-matching? f (fn [call] (= call ["foo"]))))
+                '(fn [call] (= call ["foo"]))
+                [])
+
+    (f "foo")
+    (passes-expr #(is (spy/call-matching? f (fn [call] (= call ["foo"]))))
+                 '(fn [call] (= call ["foo"]))
+                 [["foo"]])
+
+    (f "bar")
+    (fails-expr #(is (spy/call-matching? f (fn [call] (= call ["baz"]))))
+                '(fn [call] (= call ["baz"]))
+                [["foo"] ["bar"]])))
+
 (deftest error-expr-test
   (let [error (ex-info "Uh-oh!" {:some "data"})]
     (check-expr :error


### PR DESCRIPTION
I noticed that `call-matching?` was missing an implementation in `spy.assert`. Since I based the `assert-expr` implementation off of the functions in `spy.assert`, I missed implementing this as an `assert-expr`.

I do think that another pass should be done on the expected and actual messages, perhaps based on the existing ones from `spy.assert-messages`. This should be pretty straightforward, as all of the message generation functionality has been extracted to simple functions in `spy.test`.