### PR TITLE
protocol/mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.8.0] - 2021-06-21
+- Support mocking a single protocol via `protocol/mock`
+- Made `protocol/protocol-methods` private
+
 ## [2.5.0] - 2021-06-11
 - Fixed a regression where `cljs` files were not included in the release jar.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ If you are testing synchronous code then you can replace functions using [with-r
 
 ### Spying on Protocols (Experimental)
 
-Currently only Clojure is supported, I intend to make this work for ClojureScript too but it's a little trickier. I'm open to suggestions on how to improve this and support ClojureScript, all contributions are welcome!
+Currently only Clojure is supported, I intend to make this work for ClojureScript too but it's a little trickier. I'm open to suggestions on how to improve this and support ClojureScript, contributions are welcome.
 
 See `test/clj/spy/protocol_test.clj` for examples.
 
@@ -223,7 +223,7 @@ $ lein codox
 ```
 MIT License
 
-Copyright (c) 2020 Alexander James King
+Copyright (c) 2021 Alexander James King
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tortue/spy "2.7.0-SNAPSHOT"
+(defproject tortue/spy "2.8.0-SNAPSHOT"
   :description "Spy - a Clojure and ClojureScript library for stubs, spies and mocks"
   :url "https://github.com/alexanderjamesking/spy"
   :license {:name "MIT License"

--- a/src/clj/spy/protocol.clj
+++ b/src/clj/spy/protocol.clj
@@ -1,7 +1,7 @@
 (ns spy.protocol
   (:require [spy.core :as spy]))
 
-(defn protocol-methods
+(defn- protocol-methods
   "Generate a list of methods that need to be implemented for
   the protocol signatures"
   [protocol]
@@ -62,3 +62,11 @@
 
 (defn spies [instance]
   (meta instance))
+
+(defmacro mock
+  "Wraps `clojure.core/reify` with a spy on the first protocol provided.
+  Spies on a single protocol only"
+  [& opts+specs]
+  (let [protocol (first opts+specs)]
+    `(spy ~protocol
+          (clojure.core/reify ~@opts+specs))))


### PR DESCRIPTION
Currently you have to provide an implementation of a protocol that we wrap with spy, e.g:

```clojure
(protocol/spy Greeter
  (reify Greeter
    (hey [this x]
      (str "Hola " x "!"))))
```

There is a bit of repetition here, with reify we can do:

```clojure
(protocol/mock Greeter
  (hey [this x]
    (str "Bonjour " x "!")))
```

The caveat is that we can only reify a single protocol at present, but then we can only spy on a single protocol at present so it's not a big issue. We should be able to extend this to support multiple protocols later without a breaking change to the interface.