### PR TITLE
Support mocking multiple protocols

### DIFF
--- a/test/clj/spy/protocol_test.clj
+++ b/test/clj/spy/protocol_test.clj
@@ -148,3 +148,29 @@
 
     (is (= args-map (destructuring-within-definition to-spy-on args-map)))
     (is (= args-map (destructuring-within-definition spied-upon args-map)))))
+
+(defprotocol ProtocolA
+  (method-a [this x])
+  (a-not-mocked [this y z]))
+
+(defprotocol ProtocolB
+  (method-b [this x]))
+
+(deftest multi-protocols-test
+  (let [mock (protocol/mock
+              ProtocolA
+              (method-a [this x]
+                        :a)
+
+              ProtocolB
+              (method-b [this x]
+                        :b))]
+    (is (= :a (method-a mock :testing)))
+    (is (= :b (method-b mock :test)))
+    (is (spy/called-once-with? (:method-a (protocol/spies mock))
+                               mock
+                               :testing))
+
+    (is (spy/called-once-with? (:method-b (protocol/spies mock))
+                               mock
+                               :test))))


### PR DESCRIPTION
Work in progress, uses some private clojure.core methods to retrieve information about the protocol - potentially copy these over to avoid the private calls and potential future breakage.

Need to consider if and how `protocol/spy` should change here, at the moment it requires the user to pass in the protocol they are interested in and an implementation, it could just be changed to take a list of protocols but perhaps this can all be done with just an implementation and calling `.getInterfaces` on the class, needs a bit of investigation.