### PR TITLE
Make stub-throws support functions with args

### DIFF
--- a/src/cljc/spy/core.cljc
+++ b/src/cljc/spy/core.cljc
@@ -58,7 +58,7 @@
 (defn stub-throws
   "Returns a spy function that throws the exception provided."
   [exception]
-  (spy (fn [] (throw exception))))
+  (spy (fn [& _] (throw exception))))
 
 (defn calls
   "Returns a list of all calls to the spy f."

--- a/test/cljc/spy/core_test.cljc
+++ b/test/cljc/spy/core_test.cljc
@@ -190,7 +190,7 @@
     (let [ex (ex-info "Goodbye World!" {:goodbye "world"})
           f  (spy/stub-throws ex)]
       (is (thrown? #?(:cljs ExceptionInfo
-                      :clj  clojure.lang.ExceptionInfo) (f)))
+                      :clj  clojure.lang.ExceptionInfo) (f "foo" "bar")))
       (is (= 1 (count (spy/responses f))))
       (let [thrown (:thrown (spy/first-response f))]
         (is (= (ex-message ex) #?(:cljs (ex-message thrown)

--- a/test/cljc/spy/core_test.cljc
+++ b/test/cljc/spy/core_test.cljc
@@ -191,6 +191,7 @@
           f  (spy/stub-throws ex)]
       (is (thrown? #?(:cljs ExceptionInfo
                       :clj  clojure.lang.ExceptionInfo) (f "foo" "bar")))
+      (is (= [["foo" "bar"]] (spy/calls f)))
       (is (= 1 (count (spy/responses f))))
       (let [thrown (:thrown (spy/first-response f))]
         (is (= (ex-message ex) #?(:cljs (ex-message thrown)


### PR DESCRIPTION
Currently `stub-throws` only supports functions without arguments. This PR fixes it.