### PR TITLE
Fix typo in spy.protocol/mock docstring

### DIFF
--- a/src/clj/spy/protocol.clj
+++ b/src/clj/spy/protocol.clj
@@ -80,7 +80,7 @@
 (defmacro mock
   "Creates an implementation via `clojure.core/reify` and
   a wrapper to spy on the implementation, forwards all calls
-  to the implementation and records calsl in spies. Matches the
+  to the implementation and records calls in spies. Matches the
   signature and can be used directly instead of `clojure.core/reify`"
   {:style/indent [:defn [1]]}
   [& opts+specs]


### PR DESCRIPTION
## Summary  
- Fix typo: "calsl" → "calls" in spy.protocol/mock docstring

## Test plan
- [x] All tests pass after the fix

This is a minor documentation fix with no functional changes.